### PR TITLE
Make target refactor for faster builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ clean:
 
 build:
 	docker run -w /app -v ${ROOT}:/app ${GOLANG_DOCKER_IMAGE} go mod download
-	docker run -w /app -v ${ROOT}:/app ${GOLANG_DOCKER_IMAGE} go build cmd/cli/airtbl.go
 
 #   Deletes container if exists
 #   Usage:
 #       make run arguments="-help"
 run:
+	docker run -w /app -v ${ROOT}:/app ${GOLANG_DOCKER_IMAGE} go build cmd/cli/airtbl.go
 	docker run -w /app -v ${ROOT}:/app ${GOLANG_DOCKER_IMAGE} ./airtbl ${arguments}
 
 #   Usage:


### PR DESCRIPTION
This still sucks slightly but IMO better than before.

Previously, 

```
make run arguments="-api-key=XXX -base-id=XXX"
```

internally ran a `make build` which downloads go deps and then builds the code before running. Now, we pull the downloading of the go deps elsewhere.

Because we are still using `docker run` this doesn't _really_ fix the problem but at the very least it helps frequent (manual) testing during dev a bit simpler.

I may switch everything to `docker exec` soon enough as part of another MR.