### PR TITLE
appease linter

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
     - name: Checkout master
       uses: actions/checkout@v2
-      with:
-        ref: master
 
     - name: Run unit tests
       run: |

--- a/airtable_test.go
+++ b/airtable_test.go
@@ -84,7 +84,7 @@ func TestAirtable(t *testing.T) {
 		testAcc := acc()
 		testAcc.BaseUrl = ts.URL
 		tbl := NewTable("hello", testAcc)
-		tbl.List(Options{})
+		_, _ = tbl.List(Options{})
 	})
 
 	Convey("offset is passed along as expected, if there is one", t, func(c C) {
@@ -97,7 +97,7 @@ func TestAirtable(t *testing.T) {
 		testAcc := acc()
 		testAcc.BaseUrl = ts.URL
 		tbl := NewTable("hello", testAcc)
-		tbl.List(Options{
+		_, _ = tbl.List(Options{
 			Offset: "basetoken/RandomOffset",
 		})
 	})


### PR DESCRIPTION
gotta check those err values!!

Also I believe the build is failing here because `make lint fmt` on git integration is run on the master branch and not on the branch that this PR is being made from. This is also the reason that the build did not fail on the previous PR branch that also had this lint error.